### PR TITLE
#9 fixes - execution of quasar-maven-plugin by inheritance from a pom parent fails

### DIFF
--- a/src/main/java/com/vlkan/maven/plugins/quasar/QuasarInstrumentorMojo.java
+++ b/src/main/java/com/vlkan/maven/plugins/quasar/QuasarInstrumentorMojo.java
@@ -83,9 +83,6 @@ public class QuasarInstrumentorMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         getLog().info("Instrumenting Quasar classes...");
 
-        if (buildDirectory == null || !buildDirectory.isDirectory())
-            throw new MojoExecutionException("Invalid build directory: " + buildDirectory);
-
         // Create a Quasar instrumentor.
         final QuasarInstrumentor instrumentor;
         final ClassLoader cl;


### PR DESCRIPTION
… submodules fails

- deletion of unnecessary condition when buildDirectory is null.

Note : tested with multiple submodules in a maven project. Now we can declare the plugin execution in a parent pom inherited by other poms as maven sub-modules